### PR TITLE
Testing

### DIFF
--- a/l2hmc-qcd/args/args.txt
+++ b/l2hmc-qcd/args/args.txt
@@ -8,7 +8,7 @@
 --space_size 8
 --rand
 --batch_size 128
---num_steps 10
+--num_steps 5 
 --eps 0.2
 --beta_init 2.
 --beta_final 5.

--- a/l2hmc-qcd/args/gmm_args.txt
+++ b/l2hmc-qcd/args/gmm_args.txt
@@ -2,21 +2,24 @@
 --eps 0.25
 --use_nnehmc_loss
 #--use_gaussian_loss
---arrangement 'diag'
+--arrangement 'ring'
+--size 1.
+--sigma1 0.03
+--num_distributions 4 
 # --------------------
 --center 1.5
---sigma1 0.08
---sigma2 0.02
+#--sigma1 0.10
+#--sigma2 0.02
+--aux_weight 1.
 # --------------------
---global_seed 123456
+--global_seed 42
 #--float64
 # --------------------
---num_distributions 2
 --batch_size 128
 --beta_init 0.05
 --beta_final 1.
 --loss_scale 0.02
---train_steps 10000
+--train_steps 20000
 --lr_init 0.001
 --lr_decay_steps 1000
 --lr_decay_rate 0.96

--- a/l2hmc-qcd/base/base_model.py
+++ b/l2hmc-qcd/base/base_model.py
@@ -141,21 +141,22 @@ class BaseModel:
     def _create_dynamics(self, potential_fn, **params):
         """Create Dynamics Object."""
         with tf.name_scope('create_dynamics'):
-            dynamics_keys = ['eps', 'hmc', 'num_steps', 'use_bn',
-                             'dropout_prob', 'network_arch',
-                             'num_hidden1', 'num_hidden2']
-            dynamics_params = {
-                k: getattr(self, k, None) for k in dynamics_keys
+            keys = ['eps', 'hmc', 'num_steps', 'use_bn',
+                    'dropout_prob', 'network_arch',
+                    'num_hidden1', 'num_hidden2']
+
+            kwargs = {
+                k: getattr(self, k, None) for k in keys
             }
-            dynamics_params.update({
+            kwargs.update({
                 'eps_trainable': not self.eps_fixed,
                 'x_dim': self.x_dim,
                 'batch_size': self.batch_size,
                 '_input_shape': self.x.shape
             })
-            dynamics_params.update(params)
+            kwargs.update(params)
 
-            dynamics = Dynamics(potential_fn=potential_fn, **dynamics_params)
+            dynamics = Dynamics(potential_fn=potential_fn, **kwargs)
 
         return dynamics
 
@@ -204,10 +205,6 @@ class BaseModel:
                 optimizer = hvd.DistributedOptimizer(optimizer)
 
         return optimizer
-
-    def _create_dynamics(self, **kwargs):
-        """Create dynamics object used to perform augmented leapfrog update."""
-        raise NotImplementedError
 
     def _create_inputs(self):
         """Create input paceholders (if not executing eagerly).

--- a/l2hmc-qcd/config.py
+++ b/l2hmc-qcd/config.py
@@ -33,7 +33,7 @@ except ImportError:
     HAS_PSUTIL = False
 
 try:
-    from comet_ml import Experi  # noqa: F401ment
+    from comet_ml import Experiment  # noqa: F401
     HAS_COMET = True
 except ImportError:
     HAS_COMET = False
@@ -47,6 +47,7 @@ except ImportError:
 TF_FLOAT = tf.float32
 TF_INT = tf.int32
 NP_FLOAT = np.float32
+NP_INT = np.int32
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 FILE_PATH = os.path.abspath(os.path.dirname(__file__))

--- a/l2hmc-qcd/dynamics/dynamics.py
+++ b/l2hmc-qcd/dynamics/dynamics.py
@@ -19,7 +19,12 @@ import tensorflow as tf
 import numpy.random as npr
 
 from network.network import FullNet
-from config import GLOBAL_SEED, TF_FLOAT, TF_INT
+import config as cfg
+
+TF_FLOAT = cfg.TF_FLOAT
+TF_INT = cfg.TF_INT
+GLOBAL_SEED = cfg.GLOBAL_SEED
+#  from config import GLOBAL_SEED, TF_FLOAT, TF_INT
 
 
 def exp(x, name=None):

--- a/l2hmc-qcd/gmm_main.py
+++ b/l2hmc-qcd/gmm_main.py
@@ -13,9 +13,10 @@ import os
 import time
 import pickle
 
+import config as cfg
+#  from config import GLOBAL_SEED, HAS_HOROVOD, HAS_MATPLOTLIB
+from update import set_seed, set_precision
 from main import count_trainable_params, create_config, train_setup
-from config import GLOBAL_SEED, HAS_HOROVOD, HAS_MATPLOTLIB
-from update import set_seed  # , set_precision
 from models.gmm_model import GaussianMixtureModel
 from plotters.plot_utils import _gmm_plot
 from loggers.train_logger import TrainLogger
@@ -31,10 +32,10 @@ from utils.parse_gmm_args import parse_args as parse_gmm_args
 
 #  from utils.distributions import gen_ring, GMM
 
-if HAS_MATPLOTLIB:
+if cfg.HAS_MATPLOTLIB:
     import matplotlib.pyplot as plt
 
-if HAS_HOROVOD:
+if cfg.HAS_HOROVOD:
     import horovod.tensorflow as hvd
 
 if float(tf.__version__.split('.')[0]) <= 2:
@@ -42,7 +43,7 @@ if float(tf.__version__.split('.')[0]) <= 2:
 
 SEP_STR = 80 * '-'
 
-tf.set_random_seed(GLOBAL_SEED)
+tf.set_random_seed(cfg.GLOBAL_SEED)
 
 
 def create_session(config, checkpoint_dir, monitored=False):
@@ -198,7 +199,7 @@ def main(FLAGS):
     log_file = 'output_dirs.txt'
 
     USING_HVD = FLAGS.get('horovod', False)
-    if HAS_HOROVOD and USING_HVD:
+    if cfg.HAS_HOROVOD and USING_HVD:
         io.log('INFO: USING HOROVOD FOR DISTRIBUTED TRAINING')
         hvd.init()
 
@@ -212,6 +213,15 @@ if __name__ == '__main__':
     FLAGS = GMM_PARAMS
     args = parse_gmm_args()
     set_seed(args.global_seed)
+
+    io.log('\n' + 80 * '=' + '\n')
+    io.log(f'config.TF_FLOAT: {cfg.TF_FLOAT}')
+    if args.float64:
+        set_precision('float64')
+
+    io.log(f'config.TF_FLOAT: {cfg.TF_FLOAT}')
+    io.log('\n' + 80 * '=' + '\n')
+
     FLAGS.update(args.__dict__)
     t0 = time.time()
     main(FLAGS)

--- a/l2hmc-qcd/gmm_main.py
+++ b/l2hmc-qcd/gmm_main.py
@@ -203,9 +203,6 @@ def main(FLAGS):
         io.log('INFO: USING HOROVOD FOR DISTRIBUTED TRAINING')
         hvd.init()
 
-    #  if FLAGS.hmc:
-    #      inference.run_hmc(FLAGS, log_file=log_file)
-    #  else:
     model, train_logger = train_l2hmc(FLAGS, log_file)
 
 

--- a/l2hmc-qcd/inference/gmm_inference_utils.py
+++ b/l2hmc-qcd/inference/gmm_inference_utils.py
@@ -475,4 +475,3 @@ def save_inference_data(samples, px, run_dir, fig_dir,
     #              sems_naive, means_file,
     #              tag=('sem[i] = scipy.stats.sem('
     #                   'samples_therm[:, :, i].mean(axis=0))'))
-

--- a/l2hmc-qcd/inference/gmm_inference_utils.py
+++ b/l2hmc-qcd/inference/gmm_inference_utils.py
@@ -220,97 +220,6 @@ def error_analysis(samples, n=None, bs_iters=500):
     return means, errs, means_arr, samples_rs
 
 
-def alt_error_analysis(samples, num_blocks=None):
-    """Calc the mean and std error using blocked jackknife resampling. 
-
-    Args:
-        samples (array-like): Array of samples on which the error analysis will
-            be performed. 
-
-                `samples.shape = (chain_length, batch_size, dim)`,
-
-            where `dim` is the dimensionality of the target distribution.
-        num_blocks (int): Number of blocks to use in blocked jackknife
-            resampling.
-
-    Returns:
-        means (list): List containing the average value of each `component`
-            in samples. For example, if the target distribution is
-            two-dimensional, means would be `[x_avg, y_avg]`. 
-        errs (list): List containing the standard error of each `component`
-            in samples.
-
-    NOTE:
-        As an example, if `samples.shape = (1e4, 128, 2)` and 
-        `num_blocks = None`, then `chain_length = 1e4`, `batch_size = 128` and
-        `dim = 2`.
-
-        We want to calculate the average and error for each component in `dim`,
-        in this case we want `x_avg, x_err` and `y_avg, y_err`.
-
-        This is done by first calculating the values `x_avg`, and `x_err` and
-        then repeating the same calculation for `y_avg`, and `y_err`.
-
-        For simplicity, we describe the calculation of `x_avg` and `x_err`.
-
-        Let `samplesT = samples.transpose((-1, 1, 0))` with 
-        `samplesT.shape = (2, 128, 1e4)`.
-
-        Define `X, Y = samplesT` so that `X.shape = Y.shape = (128, 1e4)`.
-
-        Then
-
-        ```
-        num_blocks = X.shape[1] // 50   # 1e4 // 50 = 200
-        for x in X:
-            x_rs = block_resampling(x, num_blocks)  # x_rs.shape = (200, 9950)
-            x_rs_mean = x_rs.mean()
-            means, errs = [], []
-            for block in x_rs:
-                block_mean = block.mean()
-                denom = (num_blocks - 1) * num_blocks
-                err = np.sqrt(np.sum((block_mean - x_rs_mean)**2) / denom)
-                means.append(block_mean)
-                errs.append(err)
-        ```
-    """
-    if not isinstance(samples, np.ndarray):
-        samples = np.array(samples)
-
-    if num_blocks is None:
-        num_blocks = samples.shape[0] // 50
-
-    denom = (num_blocks - 1) * num_blocks
-
-    def mean_(x):
-        return np.mean(x, dtype=np.float64)
-
-    def err_(x, xm):
-        return np.sqrt(np.sum((mean_(x) - xm) ** 2) / denom)
-
-    samplesT = samples.transpose((-1, 1, 0))
-    # samplesT.shape = (dim, batch_size, chain_length)
-
-    means_arr = []
-    errs_arr = []
-    for component in samplesT:  # loop over dimensionality (e.g. x, y, z)
-        m_arr = []
-        e_arr = []
-        for x in component:  # loop over samples in batch
-            x_rs = block_resampling(x, num_blocks)
-            m_arr.extend([mean_(xb) for xb in x_rs])
-            e_arr.extend([sem(xb) for xb in x_rs])
-            #  m_rs = [mean_(xb) for xb in x_rs]
-            #  e_rs = [err_(xb, x_rs_mean) for xb in x_rs]
-        means_arr.append(m_arr)
-        errs_arr.append(e_arr)
-
-    means = np.array(means_arr).mean(axis=1, dtype=np.float64)
-    errs = np.array(errs_arr).mean(axis=1, dtype=np.float64)
-
-    return means, errs
-
-
 def bootstrap(data, n_boot=10000, ci=68):
     boot_dist = []
     for i in range(int(n_boot)):
@@ -318,11 +227,13 @@ def bootstrap(data, n_boot=10000, ci=68):
         sample = data.take(resampler, axis=0)
         boot_dist.append(np.mean(sample, axis=0))
     b = np.array(boot_dist)
-    s1 = np.apply_along_axis(stats.scoreatpercentile, 0, b, 50. - ci / 2.)
-    s2 = np.apply_along_axis(stats.scoreatpercentile, 0, b, 50. + ci / 2.)
+    err = np.sqrt(float(n_boot) / float(n_boot - 1)) * np.std(b)
+    mean = np.mean(b)
+    #  s1 = np.apply_along_axis(stats.scoreatpercentile, 0, b, 50. - ci / 2.)
+    #  s2 = np.apply_along_axis(stats.scoreatpercentile, 0, b, 50. + ci / 2.)
 
     mean = np.mean(b)
-    err = max(mean - s1.mean(), s2.mean() - mean)
+    #  err = max(mean - s1.mean(), s2.mean() - mean)
 
     return mean, err, b
 
@@ -350,8 +261,67 @@ def _pickle_dump(data, out_file, name=None):
         pickle.dump(data, f)
 
 
+def get_true_samples(log_dir, num_samples):
+    distribution = recreate_distribution(log_dir)
+
+    return distribution.get_samples(num_samples)
+
+
+def mean_bootstrap(samples, bs_iters, ci=68, out_file=None):
+    if not isinstance(samples, np.ndarray):
+        samples = np.array(samples)
+
+    means = []
+    errs = []
+    means_arr = []
+    axes = [i for i in range(len(samples.shape) - 1)]
+    samplesT = samples.transpose((-1, *axes))
+    for component in samplesT:
+        mean, err, arr_ = bootstrap(component, bs_iters, ci=ci)
+        means.append(mean)
+        errs.append(err)
+        means_arr.append(arr_)
+
+    if out_file is not None:
+        write_means(samples, means, errs, out_file)
+
+    return means, errs, means_arr
+
+
+def calc_autocorrelation(samples, out_dir=None):
+    spectrum = acl_spectrum(samples)
+    ess = ESS(spectrum)
+
+    if out_dir is not None:
+        spectrum_file = os.path.join(out_dir, 'acl_spectrum.pkl')
+        ess_file = os.path.join(out_dir, 'ess.txt')
+        with open(spectrum_file, 'wb') as f:
+            pickle.dump(spectrum, f)
+
+        with open(ess_file, 'w') as f:
+            _ = f.write(f'ESS: {ess}')
+
+    return spectrum, ess
+
+
+def _hist_plot(data, labels, out_file, ax=None, bins=30):
+    if ax is None:
+        _, ax = plt.subplots()
+
+    _ = ax.hist(data[0], bins=bins, label=labels[0],
+                density=True, stacked=True, alpha=1.0)
+    _ = ax.hist(data[1], bins=bins, label=labels[1],
+                density=True, stacked=True, alpha=0.6)
+    _ = ax.legend(loc='best')
+    io.log(f'Saving figure to: {out_file}.')
+    _ = plt.savefig(out_file, bbox_inches='tight')
+
+    return ax
+
+
 def save_inference_data(samples, px, run_dir, fig_dir,
-                        skip_acl=False, bs_iters=100, ignore_first=0.1):
+                        skip_acl=False, bs_iters=100,
+                        ignore_first=0.1, calc_true=True):
     """Save inference data and estimate the 'average' for each coordinate.
 
     By comparing, for example, the average `x` location (`x_mean_obs`) across
@@ -395,96 +365,114 @@ def save_inference_data(samples, px, run_dir, fig_dir,
     #  warmup_steps = samples.shape[0] // 20
     warmup_steps = int(ignore_first * samples.shape[0])
     samples_therm = samples[warmup_steps:]
-
-    samples_x = samples_therm[:, :, 0]
-    samples_y = samples_therm[:, :, 1]
-
-    x_mean_bs, x_err_bs, x_means_arr = bootstrap(samples_x, bs_iters, ci=68)
-    y_mean_bs, y_err_bs, y_means_arr = bootstrap(samples_y, bs_iters, ci=68)
-
-    means = (x_mean_bs, y_mean_bs)
-    errs = (x_err_bs, y_err_bs)
-    means_arr = (x_means_arr, y_means_arr)
+    x_dim = samples_therm.shape[-1]
+    samples_flat = samples_therm.reshape(-1, x_dim)
+    num_samples = samples_flat.shape[0]
 
     io.log(f'INFO: Ignoring first {warmup_steps} steps for thermalization...')
-    #  io.log(f'INFO: Using (naive) `np.mean` and `np.std`:')
-    x_means = samples_therm[:, :, 0].mean(axis=0)
-    x_mean = np.mean(x_means)
-    x_std = np.std(x_means)
-    x_sem = sem(x_means)
+    out_file = os.path.join(run_dir, 'means.txt')
+    means, errs, means_arr = mean_bootstrap(samples_therm, bs_iters,
+                                            ci=68, out_file=out_file)
 
-    y_means = samples_therm[:, :, 1].mean(axis=0)
-    y_mean = np.mean(y_means)
-    y_std = np.std(y_means)
-    y_sem = sem(y_means)
+    data = [i.flatten() for i in means_arr]
+    labels = [f'mean: {i:.4g} +/- {j:.4g}' for i, j in zip(means, errs)]
+    out_file = os.path.join(fig_dir, 'means_hist_observed.pdf')
 
-    means_naive = (x_mean, y_mean)
-    stds_naive = (x_std, y_std)
-    sems_naive = (x_sem, y_sem)
-    std_str_naive = f'({x_std:.5g}, {y_std:.5g})'
-    sem_str_naive = f'({x_sem:.5g}, {y_sem:.5g})'
-    mean_str_naive = f'({x_mean:.5g}, {y_mean:.5g})'
-    err_str_naive = f'{std_str_naive} (std),  {sem_str_naive} (sem)'
+    fig, ax = plt.subplots()
+    ax = _hist_plot(data, labels, out_file, ax=ax, bins=32)
+    #  fig, ax = _hist_plot(data, labels, out_file, bins=32)
 
+    if calc_true:
+        runs_dir = os.path.dirname(run_dir)
+        log_dir = os.path.abspath(os.path.dirname(runs_dir))
+        samples_true = get_true_samples(log_dir, num_samples)
+        samples_true = samples_true.reshape(samples_therm.shape)
+        out_file = os.path.join(run_dir, 'means_true.txt')
+        means, errs, means_arr = mean_bootstrap(
+            samples_true, bs_iters, ci=68, out_file=out_file
+        )
 
-    # labels to be used in histogram plot
-    label_strs = [f'mean: {i:.4g} +/- {j:.4g}' for i, j in zip(means, errs)]
+        data = [i.flatten() for i in means_arr]
+        labels = [f'mean: {i:.4g} +/- {j:.4g}' for i, j in zip(means, errs)]
+        out_file = os.path.join(fig_dir, 'means_hist_true.pdf')
 
-    err_str = f'({errs[0]:.5g}, {errs[1]:.5g})'
-    mean_str = f'({means[0]:.5g}, {means[1]:.5g})'
+        fig, ax = plt.subplots()
+        ax = _hist_plot(data, labels, out_file, ax=ax, bins=32)
+        #  fig, ax = _hist_plot(data, labels, out_file, bins=32)
 
-    means_strs = f'(x, y): {mean_str} +/- {err_str}'
-    means_strs_naive = f'(x, y): {mean_str_naive} +/- {err_str_naive}'
+    #  plt_files = []
+    #  plt_files_true = []
+    #  for d in range(x_dim):
+    #      plt_files.append(os.path.join(fig_dir,
+    #                                    f'means_hist_observed.pdf'))
+    #      plt_files_true.append(os.path.join(fig_dir,
+    #                                         f'component{d}_mean_hist_true.pdf'))
+    #
+    #  out_files = plt_files + plt_files_true
 
-    io.log(f'Using {bs_iters} bootstrap replications:\n  {means_strs}\n')
-    io.log(f'Using np.mean and std/sem:\n  {means_strs_naive}\n')
-
-    means_file = os.path.join(run_dir, 'means.txt')
-    write_means(samples, means, errs, means_file)
-    write_means(samples, means_naive,
-                stds_naive, means_file,
-                tag='std[i] = np.std(samples_therm[:, :, i].mean(axis=0))')
-    write_means(samples, means_naive,
-                sems_naive, means_file,
-                tag=('sem[i] = scipy.stats.sem('
-                     'samples_therm[:, :, i].mean(axis=0))'))
+    #  try:
+    #      data = [means_arr[0], means_arr[1]]
+    #      labels_ = [labels[0], labels[1]]
+    #      f1, ax1 = _hist_plot(data, labels_, plt_file)
+    #      if calc_true:
+    #          data
+    #          f2, ax2 = _hist_plot(, plt_file_true)
+    #  except:
+    #      import pudb; pudb.set_trace()
 
     if not skip_acl:
-        spectrum = acl_spectrum(samples)
-        ess = ESS(spectrum)
-
-        spectrum_file = os.path.join(run_dir, 'acl_spectrum.pkl')
-        ess_file = os.path.join(run_dir, 'ess.txt')
-        with open(spectrum_file, 'wb') as f:
-            pickle.dump(spectrum, f)
-
-        with open(ess_file, 'w') as f:
-            _ = f.write(f'ESS: {ess}')
-
-    out_files = [os.path.join(fig_dir, 'x_mean_histogram.pdf'),
-                 os.path.join(fig_dir, 'y_mean_histogram.pdf')]
-    xlabels = ['mean, x', 'mean, y']
-    hist_kwargs = {
-        'bins': 32,
-        'density': True,
-        'stacked': True,
-        'label': None,
-        'out_file': None,
-        'xlabel': None
-    }
-    if HAS_MATPLOTLIB:
-        for idx, x in enumerate(means_arr):
-            hist_kwargs.update({
-                'label': label_strs[idx],
-                'out_file': out_files[idx],
-                'xlabel': xlabels[idx]
-            })
-            fig, ax = plt.subplots()
-            _ = plot_histogram(x.flatten(), ax=ax, **hist_kwargs)
-
-        if not skip_acl:
+        spectrum, ess = calc_autocorrelation(samples, run_dir)
+        if HAS_MATPLOTLIB:
             acl_kwargs = {
                 'out_file': os.path.join(fig_dir,
                                          'autocorrelation_spectrum.pdf')
             }
             fig, ax = plot_acl_spectrum(spectrum, **acl_kwargs)
+
+    #  out_files = [os.path.join(fig_dir, 'x_mean_histogram.pdf'),
+    #               os.path.join(fig_dir, 'y_mean_histogram.pdf')]
+    #  xlabels = ['mean, x', 'mean, y']
+    #  samples_x = samples_therm[:, :, 0]
+    #  samples_y = samples_therm[:, :, 1]
+    #  samples_xt = samples_true[:, :, 0]
+    #  samples_yt = samples_true[:, :, 1]
+    #
+    #  x_mean_bs, x_err_bs, x_means_arr = bootstrap(samples_x, bs_iters, ci=68)
+    #  y_mean_bs, y_err_bs, y_means_arr = bootstrap(samples_y, bs_iters, ci=68)
+    #
+    #  means = (x_mean_bs, y_mean_bs)
+    #  errs = (x_err_bs, y_err_bs)
+    #  means_arr = (x_means_arr, y_means_arr)
+    #  x_means = samples_therm[:, :, 0].mean(axis=0)
+    #  x_mean = np.mean(x_means)
+    #  x_std = np.std(x_means)
+    #  x_sem = sem(x_means)
+    #
+    #  y_means = samples_therm[:, :, 1].mean(axis=0)
+    #  y_mean = np.mean(y_means)
+    #  y_std = np.std(y_means)
+    #  y_sem = sem(y_means)
+    #
+    #  means_naive = (x_mean, y_mean)
+    #  stds_naive = (x_std, y_std)
+    #  sems_naive = (x_sem, y_sem)
+    #  std_str_naive = f'({x_std:.5g}, {y_std:.5g})'
+    #  sem_str_naive = f'({x_sem:.5g}, {y_sem:.5g})'
+    #  mean_str_naive = f'({x_mean:.5g}, {y_mean:.5g})'
+    #  err_str_naive = f'{std_str_naive} (std),  {sem_str_naive} (sem)'
+
+    # labels to be used in histogram plot
+    #  means_strs = f'(x, y): {mean_str} +/- {err_str}'
+    #  means_strs_naive = f'(x, y): {mean_str_naive} +/- {err_str_naive}'
+
+    #  io.log(f'Using {bs_iters} bootstrap replications:\n  {means_strs}\n')
+    #  io.log(f'Using np.mean and std/sem:\n  {means_strs_naive}\n')
+
+    #  write_means(samples, means_naive,
+    #              stds_naive, means_file,
+    #              tag='std[i] = np.std(samples_therm[:, :, i].mean(axis=0))')
+    #  write_means(samples, means_naive,
+    #              sems_naive, means_file,
+    #              tag=('sem[i] = scipy.stats.sem('
+    #                   'samples_therm[:, :, i].mean(axis=0))'))
+

--- a/l2hmc-qcd/lattice/lattice.py
+++ b/l2hmc-qcd/lattice/lattice.py
@@ -93,6 +93,7 @@ class GaugeLattice(object):
 
         # create samples using @property method: `@samples.setter`
         self.samples = (batch_size, rand)
+        self._samples_shape = self._samples.shape
 
         self.links = self.samples[0]
         self.batch_size = self.samples.shape[0]
@@ -212,11 +213,17 @@ class GaugeLattice(object):
                                          name='top_charges')) / (2 * np.pi)
         return top_charges
 
-    def calc_top_charges_diff(self, x1, x2, plaq_sums1=None, plaq_sums2=None):
+    def calc_top_charges_diff(self, x1, x2):
         """Calculate the difference in topological charge between x1 and x2."""
         with tf.name_scope('top_charges_diff'):
-            charge_diff = tf.abs(self.calc_top_charges(x1, plaq_sums1)
-                                 - self.calc_top_charges(x2, plaq_sums2))
+            with tf.name_scope('charge1'):
+                ps1 = self.calc_plaq_sums(samples=x1)
+                q1 = self.calc_top_charges(plaq_sums=ps1)
+            with tf.name_scope('charge2'):
+                ps2 = self.calc_plaq_sums(samples=x2)
+                q2 = self.calc_top_charges(plaq_sums=ps2)
+
+            charge_diff = tf.abs(q1 - q2)
 
         return charge_diff
 

--- a/l2hmc-qcd/loggers/run_logger.py
+++ b/l2hmc-qcd/loggers/run_logger.py
@@ -62,13 +62,13 @@ class RunLogger:
         self.summaries = params['summaries']
         assert os.path.isdir(params['log_dir'])
         self.log_dir = params['log_dir']
-        if model_type is not None:
+        if model_type == 'GaussianMixtureModel':
             self.model_type = model_type
             h_strf = ("{:^12s}" + 4 * "{:^10s}").format(
                 "STEP", "t/STEP", "% ACC", "EPS", "BETA"
             )
-        else:
-            self.model_type = 'GaugeModel'
+        elif model_type == 'GaugeModel':
+            self.model_type = model_type
             h_strf = ("{:^12s}" + 8 * "{:^10s}").format(
                 "STEP", "t/STEP", "% ACC", "EPS", "BETA",
                 "ACTIONS", "PLAQS", "(EXACT)", "dQ"

--- a/l2hmc-qcd/loggers/run_logger.py
+++ b/l2hmc-qcd/loggers/run_logger.py
@@ -491,7 +491,8 @@ class RunLogger:
             run_stats = self.calc_observables_stats(self.run_data, therm_frac)
             charges = self.run_data['charges']
             charges_arr = np.array(list(charges.values()))
-            charges_autocorrs = [autocorr(x) for x in charges_arr.T]
+            charges_arrT = charges_arr.T
+            charges_autocorrs = [autocorr(x) for x in charges_arrT]
             charges_autocorrs = [x / np.max(x) for x in charges_autocorrs]
             self.run_data['charges_autocorrs'] = charges_autocorrs
 

--- a/l2hmc-qcd/models/gauge_model.py
+++ b/l2hmc-qcd/models/gauge_model.py
@@ -309,9 +309,10 @@ class GaugeModel(BaseModel):
         """Parse output dictionary from `self.dynamics.apply_transition`."""
         with tf.name_scope('top_charge_diff'):
             x_in = dynamics_output['x_in']
-            x_out = dynamics_output['x_out']
+            #  x_out = dynamics_output['x_out']
+            x_proposed = dynamics_output['x_proposed']
             x_dq = tf.cast(
-                self.lattice.calc_top_charges_diff(x_in, x_out),
+                self.lattice.calc_top_charges_diff(x_in, x_proposed),
                 dtype=TF_INT
             )
             self.charge_diffs_op = tf.reduce_sum(x_dq) / self.batch_size

--- a/l2hmc-qcd/models/gauge_model.py
+++ b/l2hmc-qcd/models/gauge_model.py
@@ -198,7 +198,7 @@ class GaugeModel(BaseModel):
     def _create_observables(self):
         """Create operations for calculating lattice observables."""
         with tf.name_scope('observables'):
-            plaq_sums = self.lattice.calc_plaq_sums(self.x)
+            plaq_sums = self.lattice.calc_plaq_sums(samples=self.x)
             actions = self.lattice.calc_actions(plaq_sums=plaq_sums)
             plaqs = self.lattice.calc_plaqs(plaq_sums=plaq_sums)
             avg_plaqs = tf.reduce_mean(plaqs, name='avg_plaqs')

--- a/l2hmc-qcd/models/gauge_model.py
+++ b/l2hmc-qcd/models/gauge_model.py
@@ -190,34 +190,6 @@ class GaugeModel(BaseModel):
 
         return dynamics
 
-    def _create_dynamics1(self, potential_fn, **params):
-        """Create `Dynamics` object."""
-        with tf.name_scope('create_dynamics'):
-            dynamics_keys = [
-                'eps', 'hmc', 'num_steps', 'use_bn',
-                'dropout_prob', 'network_arch',
-                'num_hidden1', 'num_hidden2'
-            ]
-
-            dynamics_params = {
-                k: getattr(self, k, None) for k in dynamics_keys
-            }
-
-            dynamics_params.update({
-                'eps_trainable': not self.eps_fixed,
-                'num_filters': self.lattice.space_size,
-                'x_dim': self.lattice.num_links,
-                'batch_size': self.batch_size,
-                '_input_shape': (self.batch_size, *self.lattice.links.shape),
-            })
-
-            dynamics_params.update(params)
-            samples = self.lattice.samples_tensor
-            potential_fn = self.lattice.get_potential_fn(samples)
-            dynamics = Dynamics(potential_fn=potential_fn, **dynamics_params)
-
-        return dynamics
-
     def _create_observables(self):
         """Create operations for calculating lattice observables."""
         with tf.name_scope('observables'):

--- a/l2hmc-qcd/models/gmm_model.py
+++ b/l2hmc-qcd/models/gmm_model.py
@@ -163,12 +163,14 @@ class GaussianMixtureModel(BaseModel):
             # Create dynamics for running augmented L2HMC leapfrog
             # ---------------------------------------------------------------
             io.log(f'INFO: Creating `Dynamics`...')
-            self.dynamics = self._create_dynamics()
+            self.dynamics = self.create_dynamics()
+            #  self.dynamics = self._create_dynamics()
             # Create operation for assigning to `dynamics.eps` 
             # the value fed into the placeholder `eps_ph`.
-            self.eps_setter = tf.assign(self.dynamics.eps,
-                                        self.eps_ph,
-                                        name='eps_setter')
+            self.eps_setter = self._build_eps_setter()
+            #  self.eps_setter = tf.assign(self.dynamics.eps,
+            #                              self.eps_ph,
+            #                              name='eps_setter')
 
             # ---------------------------------------------------------------
             # Create metric function for measuring 'distance' between configs
@@ -318,36 +320,9 @@ class GaussianMixtureModel(BaseModel):
             '_input_shape': (self.batch_size, self.x_dim)
         }
 
-        dynamics_params.upadte(params)
+        dynamics_params.update(params)
         potential_fn = self.distribution.get_energy_function()
-        dynamics = self._create_dynamics(potential_fn, **params)
-
-        return dynamics
-
-    def _create_dynamics1(self, potential_fn, **params):
-        """Create `Dynamics` object."""
-        with tf.name_scope('create_dynamics'):
-            dynamics_keys = [
-                'eps', 'hmc', 'num_steps', 'use_bn',
-                'dropout_prob', 'network_arch',
-                'num_hidden1', 'num_hidden2'
-            ]
-
-            dynamics_params = {
-                k: getattr(self, k, None) for k in dynamics_keys
-            }
-
-            dynamics_params.update({
-                'eps_trainable': not self.eps_fixed,
-                'num_filters': 2,
-                'x_dim': self.x_dim,
-                'batch_size': self.batch_size,
-                '_input_shape': (self.batch_size, self.x_dim),
-            })
-
-            dynamics_params.update(params)
-            potential_fn = self.distribution.get_energy_function()
-            dynamics = Dynamics(potential_fn=potential_fn, **dynamics_params)
+        dynamics = self._create_dynamics(potential_fn, **dynamics_params)
 
         return dynamics
 

--- a/l2hmc-qcd/params/gauge_params.py
+++ b/l2hmc-qcd/params/gauge_params.py
@@ -37,6 +37,8 @@ GAUGE_PARAMS = {                    # default parameters for `GaugeModel`
     'eps_fixed': False,
     'hmc': False,
     #  ------------------- LOSS PARAMS -------------------
+    'use_nnehmc_loss': False,
+    'use_gaussian_loss': False,
     'loss_scale': 0.1,
     'std_weight': 1.0,
     'aux_weight': 1.0,

--- a/l2hmc-qcd/params/gmm_params.py
+++ b/l2hmc-qcd/params/gmm_params.py
@@ -21,6 +21,7 @@ GMM_PARAMS = {                # Default parameters for `GaussianMixtureModel`
     'num_hidden2': 10,
     'save_lf': True,
     'loss_scale': 0.1,
+    'aux_weight': 1.,
     'clip_value': 0.,
     'lr_init': 1e-3,
     'warmup_lr': False,

--- a/l2hmc-qcd/plotters/gauge_model_plotter.py
+++ b/l2hmc-qcd/plotters/gauge_model_plotter.py
@@ -161,7 +161,7 @@ class GaugeModelPlotter:
         nw = net_weights
         sw, translw, transfw = nw
         title_str = (r"$N_{\mathrm{LF}} = $" + f"{lf_steps}, "
-                     r"$\varepsilon = $" + f"{eps}, "
+                     r"$\varepsilon = $" + f"{eps:.3g}, "
                      r"$N_{\mathrm{B}} = $" + f"{bs}, "
                      r"$\beta =$" + f"{beta:.2g}, "
                      r"$\mathrm{nw} = $" + (f"{nw[0]:.3g}, "
@@ -268,7 +268,7 @@ class GaugeModelPlotter:
             fname = kwargs.get('fname', f'plot_{np.random.randint(10)}')
             out_file = get_out_file(self.out_dir, fname)
             io.log(f'Saving figure to: {out_file}.')
-            plt.savefig(out_file, dpi=400, bbox_inches='tight')
+            plt.savefig(out_file, bbox_inches='tight')
 
         return fig, (ax0, ax1)
 
@@ -316,7 +316,7 @@ class GaugeModelPlotter:
 
         out_file = get_out_file(self.out_dir, 'plaqs_vs_step')
         io.log(f'Saving figure to: {out_file}')
-        plt.savefig(out_file, dpi=400, bbox_inches='tight')
+        plt.savefig(out_file, bbox_inches='tight')
 
     def _plot_plaqs_diffs(self, xy_data, **kwargs):
         kwargs['out_file'] = None
@@ -347,7 +347,7 @@ class GaugeModelPlotter:
         _ = plt.tight_layout()
         out_file = get_out_file(self.out_dir, 'plaqs_diffs_vs_step')
         io.log(f'Saving figure to: {out_file}.')
-        plt.savefig(out_file, dpi=400, bbox_inches='tight')
+        plt.savefig(out_file, bbox_inches='tight')
 
         return y_mean
 
@@ -383,7 +383,7 @@ class GaugeModelPlotter:
             out_file = get_out_file(out_dir, f'top_charge_vs_step_{idx}')
             io.check_else_make_dir(os.path.dirname(out_file))
             io.log(f'Saving figure to: {out_file}')
-            plt.savefig(out_file, dpi=400, bbox_inches='tight')
+            plt.savefig(out_file, bbox_inches='tight')
 
         plt.close('all')
 
@@ -397,13 +397,13 @@ class GaugeModelPlotter:
         # from a random configuration
         _, ax = plt.subplots()
         _ = ax.plot(xy_data[0][2:], xy_data[1][2:],
-                    marker='.', ls='', fillstyle='none', color='C0')
+                    marker=',', ls='', fillstyle='none', color='C0')
         _ = ax.set_xlabel('Steps', fontsize=14)
         _ = ax.set_ylabel(r'$\delta_{Q}$', fontsize=14)
         _ = ax.set_title(kwargs['title'], fontsize=16)
         _ = plt.tight_layout()
         io.log(f"Saving figure to: {out_file}")
-        plt.savefig(out_file, dpi=400, bbox_inches='tight')
+        plt.savefig(out_file, bbox_inches='tight')
 
     def _plot_charge_probs(self, charges, **kwargs):
         """PLot top. charge probabilities."""
@@ -432,7 +432,7 @@ class GaugeModelPlotter:
             out_file = get_out_file(out_dir, f'top_charge_vs_step_{idx}')
             io.check_else_make_dir(os.path.dirname(out_file))
             io.log(f"Saving plot to: {out_file}.")
-            plt.savefig(out_file, dpi=400, bbox_inches='tight')
+            plt.savefig(out_file, bbox_inches='tight')
             #  for f in out_file:
             #      io.check_else_make_dir(os.path.dirname(f))
             #      io.log(f"Saving plot to: {f}.")
@@ -457,7 +457,7 @@ class GaugeModelPlotter:
         out_file = get_out_file(self.out_dir, f'TOP_CHARGE_PROBS_ALL')
         io.check_else_make_dir(os.path.dirname(out_file))
         io.log(f"Saving plot to: {out_file}.")
-        plt.savefig(out_file, dpi=400, bbox_inches='tight')
+        plt.savefig(out_file, bbox_inches='tight')
         #  for f in out_file:
         plt.close('all')
 

--- a/l2hmc-qcd/plotters/gauge_model_plotter.py
+++ b/l2hmc-qcd/plotters/gauge_model_plotter.py
@@ -453,7 +453,7 @@ class GaugeModelPlotter:
         _ = ax.hist(charges_flat, bins=bins)
         _ = ax.set_ylabel(r"""Topological charge, $Q$""")
         out_file = get_out_file(self.out_dir, 'top_charge_histogram')
-        io.check_else_make_dir(os.path.sidrname(out_file))
+        io.check_else_make_dir(os.path.dirname(out_file))
         io.log(f'Saving plot to: {out_file}.')
         plt.savefig(out_file, bbox_inches='tight')
 

--- a/l2hmc-qcd/plotters/gauge_model_plotter.py
+++ b/l2hmc-qcd/plotters/gauge_model_plotter.py
@@ -450,7 +450,7 @@ class GaugeModelPlotter:
         bins = np.unique(charges_flat)
 
         _, ax = plt.subplots()
-        _ = ax.histogram(charges_flat, bins=bins)
+        _ = ax.hist(charges_flat, bins=bins)
         _ = ax.set_ylabel(r"""Topological charge, $Q$""")
         out_file = get_out_file(self.out_dir, 'top_charge_histogram')
         io.check_else_make_dir(os.path.sidrname(out_file))

--- a/l2hmc-qcd/plotters/gauge_model_plotter.py
+++ b/l2hmc-qcd/plotters/gauge_model_plotter.py
@@ -104,7 +104,9 @@ class GaugeModelPlotter:
         autocorrs_avg = np.mean(charge_autocorrs.T, axis=1)
         autocorrs_err = sem(charge_autocorrs.T, axis=1)
 
-        num_steps, batch_size = actions.shape
+        #  num_steps, batch_size = actions.shape
+        num_steps = actions.shape[0]
+        batch_size = actions.shape[1]
         steps_arr = np.arange(num_steps)
 
         # skip 5% of total number of steps between successive points when

--- a/l2hmc-qcd/plotters/gauge_model_plotter.py
+++ b/l2hmc-qcd/plotters/gauge_model_plotter.py
@@ -38,8 +38,6 @@ class GaugeModelPlotter:
         self.figs_dir = figs_dir
         self.params = params
         #  self.model = model
-        if experiment is not None:
-            self.experiment = experiment
 
     def calc_stats(self, data, therm_frac=10):
         """Calculate observables statistics.
@@ -87,12 +85,6 @@ class GaugeModelPlotter:
         }
 
         return stats
-
-    def log_figure(self):
-        try:
-            self.experiment.log_figure()
-        except AttributeError:
-            pass
 
     def _parse_data(self, data, beta):
         """Helper method for extracting relevant data from `data`.'"""
@@ -185,20 +177,15 @@ class GaugeModelPlotter:
         """Plot observables."""
         xy_data, kwargs = self._plot_setup(data, **kwargs)
 
-        self._plot_actions(xy_data['actions'], **kwargs)
-        self.log_figure()
         self._plot_plaqs(xy_data['plaqs'], **kwargs)
-        self.log_figure()
+        self._plot_actions(xy_data['actions'], **kwargs)
         self._plot_charges(xy_data['charges'], **kwargs)
-        self.log_figure()
-        self._plot_charge_probs(xy_data['charges'][1], **kwargs)
-        self.log_figure()
-        self._plot_charge_diffs(xy_data['charge_diffs'], **kwargs)
-        self.log_figure()
         self._plot_autocorrs(xy_data['autocorrs'], **kwargs)
-        self.log_figure()
+        # take xy_data['charges'][1] since we're only concerned with 'y' data
+        self._plot_charge_probs(xy_data['charges'][1], **kwargs)
+        self._plot_charges_hist(xy_data['charges'][1], **kwargs)
+        self._plot_charge_diffs(xy_data['charge_diffs'], **kwargs)
         mean_diff = self._plot_plaqs_diffs(xy_data['plaqs_diffs'], **kwargs)
-        self.log_figure()
 
         return mean_diff
 
@@ -433,9 +420,6 @@ class GaugeModelPlotter:
             io.check_else_make_dir(os.path.dirname(out_file))
             io.log(f"Saving plot to: {out_file}.")
             plt.savefig(out_file, bbox_inches='tight')
-            #  for f in out_file:
-            #      io.check_else_make_dir(os.path.dirname(f))
-            #      io.log(f"Saving plot to: {f}.")
         plt.close('all')
 
         all_counts = Counter(list(charges.flatten()))
@@ -458,8 +442,20 @@ class GaugeModelPlotter:
         io.check_else_make_dir(os.path.dirname(out_file))
         io.log(f"Saving plot to: {out_file}.")
         plt.savefig(out_file, bbox_inches='tight')
-        #  for f in out_file:
         plt.close('all')
+
+    def _plot_charges_hist(self, charges, **kwargs):
+        charges = np.array(charges, dtype=int)
+        charges_flat = charges.flatten()
+        bins = np.unique(charges_flat)
+
+        _, ax = plt.subplots()
+        _ = ax.histogram(charges_flat, bins=bins)
+        _ = ax.set_ylabel(r"""Topological charge, $Q$""")
+        out_file = get_out_file(self.out_dir, 'top_charge_histogram')
+        io.check_else_make_dir(os.path.sidrname(out_file))
+        io.log(f'Saving plot to: {out_file}.')
+        plt.savefig(out_file, bbox_inches='tight')
 
     def _plot_autocorrs(self, xy_data, **kwargs):
         """Plot topological charge autocorrelations."""

--- a/l2hmc-qcd/plotters/plot_utils.py
+++ b/l2hmc-qcd/plotters/plot_utils.py
@@ -490,23 +490,24 @@ def gmm_plot(distribution, samples, **kwargs):
                         alpha=1., markersize=1.5, zorder=10)
             _ = ax.axis(axis_scale)
 
-            xtl, ytl = _get_ticks_labels(ax)
-            _ = ax.set_xticks([])
-            _ = ax.set_yticks([])
-            _ = ax.set_xlim(xlims)
-            _ = ax.set_ylim(ylims)
+            #  xtl, ytl = _get_ticks_labels(ax)
+            if ax != axes[-1, 0]:     # Keep ticks/labels on lower left subplot
+                _ = ax.set_xticks([])
+                _ = ax.set_yticks([])
+                _ = ax.set_xlim(xlims)
+                _ = ax.set_ylim(ylims)
 
             idx += 1
 
-    xticks, xticklabels = xtl
-    yticks, yticklabels = ytl
+    #  xticks, xticklabels = xtl
+    #  yticks, yticklabels = ytl
 
-    _ = axes[-1, 0].set_yticks(yticks)
-    _ = axes[-1, 0].set_yticklabels(yticklabels)
-    _ = axes[-1, 0].set_xticks(xticks)
-    _ = axes[-1, 0].set_xticklabels(xticklabels)
-    _ = axes[-1, 0].axis(axis_scale)
-
+    #  _ = axes[-1, 0].set_yticks(yticks)
+    #  _ = axes[-1, 0].set_yticklabels(yticklabels)
+    #  _ = axes[-1, 0].set_xticks(xticks)
+    #  _ = axes[-1, 0].set_xticklabels(xticklabels)
+    #  _ = axes[-1, 0].axis(axis_scale)
+    #
     # _ = fig.tight_layout()
 
     if title is not None:

--- a/l2hmc-qcd/runners/gauge_model_runner.py
+++ b/l2hmc-qcd/runners/gauge_model_runner.py
@@ -94,7 +94,7 @@ class GaugeModelRunner:
 
         out_data = {
             'step': step,
-            'beta_np': beta_np,
+            'beta': beta_np,
             'eps': self.eps,
             'samples': np.mod(outputs[0], 2 * np.pi),
             'samples_orig': outputs[0],
@@ -149,14 +149,19 @@ class GaugeModelRunner:
 
         has_logger = self.logger is not None
 
-        x_dim = self.params['x_dim']
-        samples_np = np.random.randn(*(self.params['batch_size'], x_dim))
+        #  x_dim = self.params['x_dim']
+        samples_np = kwargs.get('samples', None)
+        if samples_np is None:
+            x_dim = (self.params['space_size']
+                     * self.params['time_size']
+                     * self.params['dim'])
+            samples_np = np.random.randn(*(self.params['batch_size'], x_dim))
 
         io.log(self._run_header)
         for step in range(run_steps):
             inputs = (samples_np, beta, self.eps, plaq_exact)
-            out_data, data_str = self.run_step(step, run_steps, inputs,
-                                               net_weights)
+            out_data, data_str = self.run_step(step, run_steps,
+                                               inputs, net_weights)
             samples_np = out_data['samples']
 
             if has_logger:

--- a/l2hmc-qcd/runners/gmm_runner.py
+++ b/l2hmc-qcd/runners/gmm_runner.py
@@ -107,7 +107,8 @@ class GaussianMixtureModelRunner:
         x_dim = self.params.get('x_dim', None)
         samples_np = kwargs.get('samples', None)  # initial sample configs
         if samples_np is None:
-            samples_np = np.random.rand(*(self.params['batch_size'], x_dim))
+            samples_np = np.ones((self.params['batch_size'], x_dim))
+            #  samples_np = np.random.rand(*(self.params['batch_size'], x_dim))
         #  samples_np = np.random.randn(*(self.params['batch_size'], x_dim))
 
         for step in range(run_steps):

--- a/l2hmc-qcd/utils/file_io.py
+++ b/l2hmc-qcd/utils/file_io.py
@@ -58,12 +58,13 @@ def log_and_write(s, f):
 def copy(src, dest):
     try:
         shutil.copytree(src, dest)
-    except OSError as e:
+    except OSError:
         # If the error was caused because the source wasn't a directory
-        if e.errno == errno.ENOTDIR:
+        #  if e.errno == errno.ENOTDIR:
+        try:
             shutil.copy(src, dest)
-        else:
-            log(f'Directory not copied. Error: {e}')
+        except OSError as ee:
+            log(f'Directory not copied. Error: {ee}')
 
 
 def check_else_make_dir(d):
@@ -93,18 +94,18 @@ def _parse_gauge_flags(FLAGS):
         except (NameError, AttributeError):
             pass
     try:
-        LX = flags_dict['space_size']
-        BS = flags_dict['batch_size']
-        LF = flags_dict['num_steps']
-        SS = flags_dict['eps']
-        QW = flags_dict['charge_weight']
-        NA = flags_dict['network_arch']
-        BN = flags_dict['use_bn']
-        DP = flags_dict['dropout_prob']
-        AW = flags_dict['aux_weight']
-        GL = flags_dict['use_gaussian_loss']
-        NL = flags_dict['use_nnehmc_loss']
-        hmc = flags_dict['hmc']
+        LX = flags_dict.get('space_size', None)
+        BS = flags_dict.get('batch_size', None)
+        LF = flags_dict.get('num_steps', None)
+        SS = flags_dict.get('eps', None)
+        QW = flags_dict.get('charge_weight', None)
+        NA = flags_dict.get('network_arch', None)
+        BN = flags_dict.get('use_bn', None)
+        DP = flags_dict.get('dropout_prob', None)
+        AW = flags_dict.get('aux_weight', None)
+        GL = flags_dict.get('use_gaussian_loss', None)
+        NL = flags_dict.get('use_nnehmc_loss', None)
+        hmc = flags_dict.get('hmc', None)
         try:
             _log_dir = flags_dict['log_dir']
         except KeyError:
@@ -182,6 +183,7 @@ def _parse_gmm_flags(FLAGS):
         S2 = flags_dict.get('sigma2', None)
         GL = flags_dict.get('use_gaussian_loss', False)
         NL = flags_dict.get('use_nnehmc_loss', False)
+        AW = flags_dict.get('aux_weight', 1.)
         AR = flags_dict.get('arrangement', 'xaxis')
     except (NameError, AttributeError):
         X0 = FLAGS.center
@@ -192,6 +194,7 @@ def _parse_gmm_flags(FLAGS):
         S2 = FLAGS.sigma2
         GL = FLAGS.use_gaussian_loss
         NL = FLAGS.use_nnehmc_loss
+        AW = FLAGS.aux_weight
         AR = FLAGS.arrangement
 
     out_dict = {
@@ -203,13 +206,15 @@ def _parse_gmm_flags(FLAGS):
         'S2': S2,
         'GL': GL,
         'NL': NL,
+        'AW': AW,
         'AR': AR,
     }
 
     #  x0 = str(X0).replace('.', '')
+    aw = str(AW).replace('.', '')
     s1 = str(S1).replace('.', '')
     s2 = str(S2).replace('.', '')
-    run_str = f'GMM_{AR}_lf{LF}_s1_{s1}_s2_{s2}'
+    run_str = f'GMM_{AR}_lf{LF}_aw{aw}_s1_{s1}_s2_{s2}'
 
     if GL and NL:
         run_str += '_gaussian_nnehmc_loss'
@@ -256,7 +261,7 @@ def create_log_dir(FLAGS, root_dir=None, log_file=None,
     now = datetime.datetime.now()
     #  print(now.strftime("%b %d %Y %H:%M:%S"))
     day_str = now.strftime('%Y_%m_%d')
-    time_str = now.strftime("%Y_%m_%d_%H%M")
+    #  time_str = now.strftime("%Y_%m_%d_%H%M")
     hour_str = now.strftime('%H%M')
 
     project_dir = os.path.abspath(os.path.dirname(FILE_PATH))

--- a/l2hmc-qcd/utils/parse_gmm_args.py
+++ b/l2hmc-qcd/utils/parse_gmm_args.py
@@ -128,6 +128,26 @@ def parse_args():
                         help=("""If passed, set `use_nnehmc_loss=True` and
                               use alternative NNEHMC loss function."""))
 
+    parser.add_argument('--nnehmc_beta',
+                        dest='nnehmc_beta',
+                        default=1.,
+                        required=False,
+                        help=("""Value of `beta` to use when calculating the
+                              NNEHMC loss. Note that beta multiplies the HMC
+                              acceptance probability in Eq. 14. of
+                              https://link.springer.com/chapter/10.1007/978-3-030-20351-1_64
+                              (Default: 1., but only applies when
+                              `--use_nnehmc_loss` is True."""))  # noqa: E501
+
+    parser.add_argument("--aux_weight",
+                        dest="aux_weight",
+                        type=float,
+                        default=1.,
+                        required=False,
+                        help=("""Multiplicative factor used to weigh relative
+                              strength of auxiliary term in loss function.
+                              (Default: 1.)"""))
+
     parser.add_argument('--loss_scale',
                         dest='loss_scale',
                         type=float,

--- a/l2hmc-qcd/utils/parse_inference_args.py
+++ b/l2hmc-qcd/utils/parse_inference_args.py
@@ -54,6 +54,16 @@ def parse_args():
                               is passed, `eps = None` and the optimal step size
                               (determined during training) will be used."""))
 
+    parser.add_argument('--samples_init',
+                        dest='samples_init',
+                        type=str,
+                        default='random',
+                        required=False,
+                        help=("""String specifying how to initialize samples
+                              when running inference. Possible values are:
+                              'zeros', 'ones', or 'random'.
+                              (Default: 'random')"""))
+
     parser.add_argument('--bootstrap_iters',
                         dest='bootstrap_iters',
                         type=int,


### PR DESCRIPTION
Move code for building `Dynamics` object into `_create_sampler` method of `BaseModel`.

- Changes to how figures are created when running inference on a trained `GaugeModel`.

- Implement error analysis using the bootstrap method as opposed to blocked jackknife resampling 
   when running inference on trained `GaussianMixtureModel` sampler.

- General improvements to histogram plots (in `plotters/plot_utils.py`) when running inference on 
   trained `GaussianMixtureModel` sampler.

- Create `--samples_init` flag that can be passed to either `gauge_inference.py` or 
  `gmm_inference.py` that allows for specifying how samples are initialized at the beginning of an 
   inference run. Allowed values are `'random'`, `'zeros'`, or `'ones'`.

- Change how the global floating point precision is specified when passing `--float64` as a 
   command line argument to either `main.py` or `gmm_main.py`.

- Rename `GaugeModel._create_dynamics()` method to `GaugeModel.create_dynamics()` and 
   move the `_create_dynamics()` method to the `BaseModel` class.